### PR TITLE
fix: install systemd-resolved only from Debian 12 (bookworm and after)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,9 @@
   ansible.builtin.package:
     name: systemd-resolved
     state: present
+  when:
+    - ansible_distribution | lower == 'debian'
+    - ansible_distribution_major_version >= '12'
 
 - name: enable systemd-networkd
   become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,8 +10,8 @@
     name: systemd-resolved
     state: present
   when:
-    - ansible_distribution | lower == 'debian'
-    - ansible_distribution_major_version >= '12'
+    - ansible_facts.distribution | lower == 'debian'
+    - ansible_facts.distribution_major_version >= '12'
 
 - name: enable systemd-networkd
   become: true


### PR DESCRIPTION
Ensure retro compatibility with Debian 11 and don't install systemd-resolved when not needed